### PR TITLE
Enable the link-tooltip module by default

### DIFF
--- a/src/Quill.vue
+++ b/src/Quill.vue
@@ -64,7 +64,7 @@
 
             ready() {
                 this.editor = new Quill(this.$els.quill, {
-                    modules: { toolbar: this.$els.toolbar },
+                    modules: { toolbar: this.$els.toolbar, 'link-tooltip': true },
                     theme: 'snow',
                 })
 


### PR DESCRIPTION
Adding `<a class="ql-format-button ql-link"></a>` to the toolbar requires the link-tooltip module to be loaded. This update ensures it is ready by default.