### PR TITLE
Update to Vue 2.x and Quill 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Install the vue plugin
 Vue.use(require('vue-quill'))
 ```
 ### Component
+
+To be able to update the variable value (due to the "one-way-down" binding of Vue 2) you'll need to listen to the `quill-update` event
 ```html
-<quill :content="content"></quill>
+<quill :content="content" v-on:quill-update="methodToUpdateContent"></quill>
 ```
 You may want to initialize the variable as a valid delta object too
 
@@ -33,6 +35,11 @@ data() {
             ops: [],
         },
     }
+},
+methods: {
+  methodToUpdateContent(content) {
+    this.content = content;
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ A vue component wrapping the quill editor
 npm install --save vue-quill
 ```
 
-You will also need to include the following css file in your project
+You will also need to include the css file matching your chosen theme in your project
 ```html
-<link href="https://cdnjs.cloudflare.com/ajax/libs/quill/0.20.1/quill.snow.min.css" rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/quill/1.1.5/quill.snow.min.css" rel="stylesheet">
+```
+or
+```html
+<link href="https://cdnjs.cloudflare.com/ajax/libs/quill/1.1.5/quill.bubble.min.css" rel="stylesheet">
 ```
 
 ## Usage
@@ -18,9 +22,9 @@ Vue.use(require('vue-quill'))
 ```
 ### Component
 ```html
-<quill :content.sync="content"></quill>
+<quill :content="content"></quill>
 ```
-You may want to initialize the synced variable as a valid delta object too
+You may want to initialize the variable as a valid delta object too
 
 ```js
 data() {
@@ -34,7 +38,7 @@ data() {
 
 ### Configuration
 ```html
-<quill :content.sync="content" :config="config"></quill>
+<quill :content="content" :config="config"></quill>
 ```
 You can also provide a config object as described in http://quilljs.com/docs/configuration/
 
@@ -56,13 +60,13 @@ data() {
 The plugin also installs a custom filter for converting a delta object to raw html
 
 ```html
-{{{ content | quill }}}
+<span v-html="content | quill"></span>
 ```
 
 ## Options
 By default, the component outputs the content as a delta object, you can pass in a prop to return raw html
 ```html
-<quill :content.sync="content" output="html"></quill>
+<quill :content="content" output="html"></quill>
 ```
 
 ## Custom Formats
@@ -85,18 +89,22 @@ keyBindings: [
     {
         key: 's',
         method: function(range) {
-            this.$dispatch('save', this.editor, range)
-            return false        
+            this.$emit('save', this.editor, range)
+            return false
         },
     },
 ]
 ```
 
 ## Events
-This quill component dispatches events when the text or selection changes on the quill editor, you can listen for these on the parent component by declaring an event similar to this
+This quill component emit events when the text or selection changes on the quill editor, you can listen for these on the parent component by declaring an event similar to this
+```html
+<quill :content="content" v-on:selection-change="selectionChange"></quill>
+```
+
 ```js
-events: {
-    'selection-change'(editor, range) {
+methods: {
+    selectionChange(editor, range) {
         if (range) {
             if (range.start !== range.end) {
                 this.selectedText = editor.getText(range.start, range.end)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/CroudSupport/vue-quill#readme",
   "dependencies": {
-    "quill": "^0.20.1",
+    "quill": "^1.1.5",
     "quill-render": "^1.0.5"
   }
 }

--- a/src/Quill.vue
+++ b/src/Quill.vue
@@ -1,139 +1,120 @@
 <template>
-    <div>
-        <div v-el:toolbar class="ui top attached menu toolbar ql-toolbar ql-snow">
-            <slot name="toolbar">
-                <div class="ql-format-group">
-                    <a class="ql-format-button ql-bold"></a>
-                    <span class="ql-format-separator"></span>
-                    <a class="ql-format-button ql-underline"></a>
-                    <span class="ql-format-separator"></span>
-                    <a class="ql-format-button ql-italic"></a>
-                </div>
-                <div class="ql-format-group">
-                    <a class="ql-format-button ql-list"></a>
-                    <span class="ql-format-separator"></span>
-                    <a class="ql-format-button ql-bullet"></a>
-                    <span class="ql-format-separator"></span>
-                    <span title="Text Alignment" class="ql-align ql-picker">
-                        <span class="ql-picker-label" data-value="left"></span>
-                        <span class="ql-picker-options">
-                            <span data-value="left" class="ql-picker-item ql-selected"></span>
-                            <span data-value="center" class="ql-picker-item"></span>
-                            <span data-value="right" class="ql-picker-item"></span>
-                            <span data-value="justify" class="ql-picker-item"></span>
-                        </span>
-                    </span>
-                </div>
-            </slot>
-        </div>
-        <div class="ui attached segment" v-el:quill @click.prevent="focusEditor"></div>
-    </div>
+  <div class="ui attached segment"
+       @click.prevent="focusEditor"
+       v-on:focus-editor="focusEditor"
+       v-on:set-html="setHTML"
+       v-on:set-content="setContents">
+  </div>
 </template>
 
 <script>
     const Quill = require('quill')
     export default {
         props: {
-            content: {},
-
-            author: {},
-
-            formats: {
-                type: Array,
-                default() {
-                    return []
-                },
-            },
-
-            keyBindings: {
-                type: Array,
-                default() {
-                    return []
-                },
-            },
-
-            output: {
-                default : 'delta'
-            },
-
-            keyup: {
-                default : null
-            },
-
-            config: {
-                default() {
-                    return {
-                        modules: { 'link-tooltip': true },
-                        theme: 'snow',
-                    }
-                },
-            },
+          content: {},
+          author: {},
+          formats: {
+            type: Array,
+            default: () => [],
+          },
+          keyBindings: {
+            type: Array,
+            default: () => [],
+          },
+          output: { default : 'delta', },
+          keyup: { default : null, },
+          config: {
+            type: Object,
+            default: () => { return {} },
+          },
         },
 
         data() {
-            return {
-                editor: {},
-            }
+          return {
+            editor: {},
+            editorContent: this.content,
+            defaultConfig: {
+              modules: {
+                toolbar: [
+                  [{ 'font': [] }],
+                  [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+                  ['bold', 'italic', 'underline', 'strike'],
+                  ['blockquote', 'code-block'],
+                  [
+                    { 'list': 'ordered' }, { 'list': 'bullet' }
+                  ],
+                  [
+                    { 'script': 'sub' }, { 'script': 'super' }
+                  ],
+                  [
+                    { 'indent': '-1' }, { 'indent': '+1' }
+                  ],
+                  [
+                    { 'color': [] }, { 'background': [] }
+                  ],
+                  [{ 'align': [] }],
+                  ['clean'],
+                ],
+              },
+              theme: 'snow',
+            },
+          },
         },
 
-        ready() {
-            console.log(this.config)
-            this.editor = new Quill(this.$els.quill, this.config)
-            this.editor.addModule('toolbar', this.$els.toolbar)
+        mounted() {
+          this.editor = new Quill(this.$el, this.setOptions(this.defaultConfig, this.config))
 
-            this.formats.map((format) => {
-                this.editor.addFormat(format.name, format.options)
+          this.formats.map((format) => {
+            this.editor.addFormat(format.name, format.options)
+          })
+
+          if (this.output !== 'delta') {
+            this.editor.root.innerHTML = this.editorContent
+          } else {
+            this.editor.setContents(this.editorContent)
+          }
+
+          this.editor.on('text-change', (delta, source) => {
+            this.$emit('text-change', this.editor, delta, source)
+            this.editorContent = this.output !== 'delta' ? this.editor.root.innerHTML : this.editor.getContents()
+          })
+
+          this.editor.on('selection-change', (range) => {
+            this.$emit('selection-change', this.editor, range)
+          })
+
+          if (typeof this.author !== 'undefined') {
+            this.editor.addModule('authorship', {
+              authorId: this.author,
             })
+          }
 
-            if (this.output != 'delta') {
-                this.editor.setHTML(this.content);
-            } else {
-                this.editor.setContents(this.content);
-            }
+          if (this.keyBindings.length) {
+            const keyboard = this.editor.getModule('keyboard')
 
-            this.editor.on('text-change', (delta, source) => {
-                this.$dispatch('text-change', this.editor, delta, source)
-                this.content = this.output != 'delta' ? this.editor.getHTML() : this.editor.getContents()
+            this.keyBindings.map((binding) => {
+              keyboard.addHotkey({ key: binding.key, metaKey: true }, binding.method.bind(this))
             })
-
-            this.editor.on('selection-change', (range) => {
-                this.$dispatch('selection-change', this.editor, range)
-            })
-
-            if (typeof this.author !== 'undefined') {
-                this.editor.addModule('authorship', {
-                    authorId: this.author,
-                })
-            }
-
-            if (this.keyBindings.length) {
-                const keyboard = this.editor.getModule('keyboard')
-
-                this.keyBindings.map((binding) => {
-                    keyboard.addHotkey({ key: binding.key, metaKey: true }, binding.method.bind(this))
-                })
-            }
-        },
-
-        events: {
-            'set-content' : function (content) {
-                this.editor.setContents(content)
-            },
-
-            'set-html' : function (html) {
-                this.editor.setHTML(html)
-            },
-
-            'focus-editor' : function () {
-                this.focusEditor()
-            }
+          }
         },
 
         methods: {
-            focusEditor(e) {
+            setOptions(defaults, properties) {
+              for (let property in properties) {
+                if (properties.hasOwnProperty(property)) {
+                  if (typeof properties[property] === Object) {
+                    defaults[property] = this.setOptions(defaults[property], properties[property]);
+                  } else {
+                    defaults[property] = properties[property]
+                  }
+                }
+              }
 
+              return defaults
+            },
+            focusEditor(e) {
                 if (e && e.srcElement) {
-                    let classList = e.srcElement.classList, isSegment = false;
+                    let classList = e.srcElement.classList, isSegment = false
 
                     classList.forEach((className) => {
                         if (className === 'segment') {
@@ -142,16 +123,19 @@
                         }
                     })
 
-                    if (!isSegment) return;
+                    if (!isSegment) return
                 }
 
                 this.editor.focus()
 
                 this.editor.setSelection(this.editor.getLength()-1, this.editor.getLength())
-
-
+            },
+            setContents(content) {
+              this.editor.setContents(content)
+            },
+            setHTML(html) {
+              this.editor.root.innerHTML = html
             }
-
         },
     }
 </script>

--- a/src/Quill.vue
+++ b/src/Quill.vue
@@ -32,7 +32,6 @@
         data() {
           return {
             editor: {},
-            editorContent: this.content,
             defaultConfig: {
               modules: {
                 toolbar: [
@@ -69,14 +68,14 @@
           })
 
           if (this.output !== 'delta') {
-            this.editor.root.innerHTML = this.editorContent
+            this.editor.root.innerHTML = this.content
           } else {
-            this.editor.setContents(this.editorContent)
+            this.editor.setContents(this.content)
           }
 
           this.editor.on('text-change', (delta, source) => {
             this.$emit('text-change', this.editor, delta, source)
-            this.editorContent = this.output !== 'delta' ? this.editor.root.innerHTML : this.editor.getContents()
+            this.$emit('quill-update', this.output !== 'delta' ? this.editor.root.innerHTML : this.editor.getContents())
           })
 
           this.editor.on('selection-change', (range) => {


### PR DESCRIPTION
This is an updated version of vue-quill for VueJS 2 and Quill 1.1.x

Quill remove the `setHTML` and `getHTML` in v1, thus I used a "hack" : `this.editor.root.innerHTML`.

Instead of using a toolbar `<slot>` I preferred the object version, since it's way easier to use and change.

Also, a big issue was the "one-way-down" binding of Vue 2, thus it's needed to use events to pass the data from the child to the parent. (see README)
A custom store could be use  for a cleaner solution, but that'll require more tweak to do for the user.

For the filters, I'm not sure if the render will still work properly (due to the `{{{ }}}` deprecation). Not sure if you can use a filter in `v-html`. 

Still need to do some test and tweaks, but most of the work is done.
I'm PRing it while it's still **wip** to open a discussion about the changes I made, if you have any questions or remarks, I'm here.