### PR TITLE
Remove tabIndex from the toolbar elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-quill",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Vue quill component and filter",
   "main": "vue-quill.js",
   "browserify": {

--- a/src/Quill.vue
+++ b/src/Quill.vue
@@ -120,6 +120,16 @@
 
                 this.editor.root.innerHTML = html
             })
+
+            this.$nextTick(() => {
+                const selectors = ['button', '.ql-picker-label', '.ql-picker-item']
+                const toolbar = this.$el.querySelector('.ql-toolbar')
+                selectors.forEach((selector) => {
+                    toolbar.querySelectorAll(selector).forEach((element) => {
+                        element.tabIndex = -1
+                    })
+                })
+            })
         },
 
         methods: {


### PR DESCRIPTION
Removes the tabIndex from the quill toolbar element.
This allows the user to tab straight to the content rather than having to tab through the toolbar first.