### PR TITLE
Feature/empty text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-quill",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Vue quill component and filter",
   "main": "vue-quill.js",
   "browserify": {

--- a/src/Quill.vue
+++ b/src/Quill.vue
@@ -96,7 +96,11 @@
 
             this.editor.on('text-change', (delta, source) => {
                 this.$emit('text-change', this.editor, delta, source)
-                this.$emit('input', this.output != 'delta' ? this.editor.root.innerHTML : this.editor.getContents())
+                if (this.editor.getText().length <= 1) {
+                  this.$emit('input', '')
+                } else {
+                  this.$emit('input', this.output != 'delta' ? this.editor.root.innerHTML : this.editor.getContents())
+                }
             })
 
             this.editor.on('selection-change', (range) => {


### PR DESCRIPTION
If the quill component is empty, we return an empty string rather than the quill defaults.